### PR TITLE
Build and link Box2D in the build script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Box2D"]
+	path = Box2D
+	url = git@github.com:erincatto/Box2D.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Box2D"]
 	path = Box2D
-	url = git@github.com:erincatto/Box2D.git
+	url = https://github.com/erincatto/Box2D.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,6 @@ addons:
     packages:
     - cmake
 
-before_install:
-- git clone https://github.com/erincatto/Box2D
-- cd Box2D
-- git reset --hard 7e633c4
-- cd Box2D/Build
-- cmake -DBOX2D_INSTALL=ON -DBOX2D_BUILD_SHARED=ON -DBOX2D_BUILD_EXAMPLES=OFF ..
-- make && sudo make install
-- sudo ldconfig
-- cd ../../..
-
 script:
 - cargo build --all-features --verbose
 - cargo test --all-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrapped2d"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Thomas Koehler <basta.t.k+git@gmail.com>"]
 
 description = "Rust binding for Box2D"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrapped2d"
-version = "0.3.5"
+version = "0.4.0"
 authors = ["Thomas Koehler <basta.t.k+git@gmail.com>"]
 
 description = "Rust binding for Box2D"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,23 @@ license = "zlib-acknowledgement"
 
 build = "build.rs"
 
+exclude = [
+    "Box2D/Contributions/*",
+    "Box2D/Box2D/Build/*",
+    "Box2D/Box2D/Documentation/*",
+    "Box2D/Box2D/glew/*",
+    "Box2D/Box2D/glfw/*",
+    "Box2D/Box2D/HelloWorld/*",
+    "Box2D/Box2D/Testbed/*",
+]
+
 [features]
 serialize = ["serde", "serde_derive"]
 default = []
 
 [build-dependencies]
-gcc = "^0.3"
+cc = "^1.0"
+cmake = "^0.1"
 
 [dependencies]
 libc = "^0.2"

--- a/README.md
+++ b/README.md
@@ -15,14 +15,8 @@ You can look at the [testbed](testbed) for examples.
 
 You will need [CMake](https://cmake.org/) installed in order to build Box2D.
 
-Alternatively, you can supply your own installation of Box2D ([version 2.3.1](https://github.com/erincatto/Box2D/releases/tag/v2.3.1)) by pointing the `BOX2D_INCLUDE_PATH` environment variable to the Box2D header files. For example:
+Alternatively, you can supply your own installation of Box2D ([version 2.3.1](https://github.com/erincatto/Box2D/releases/tag/v2.3.1)) by pointing the `BOX2D_LIB_DIR` environment variable to the directory containing the compiled Box2D library. For example:
 
 ~~~~sh
-BOX2D_INCLUDE_PATH="path/to/Box2D/Box2D" cargo build
-~~~~
-
-In that case, the Box2D library must be available on rustc's library search path. If this is not the case, you can manually add it:
-
-~~~~sh
-RUSTFLAGS="-L path/to/Box2D/lib_dir"
+BOX2D_LIB_DIR="path\to\Box2D\lib" cargo build
 ~~~~

--- a/README.md
+++ b/README.md
@@ -13,11 +13,16 @@ You can look at the [testbed](testbed) for examples.
 
 ## Dependencies
 
-You will need the native Box2D library (this is based on [version 2.3.1](https://github.com/erincatto/Box2D/releases/tag/v2.3.1)).  
-For example, you can install it on your system with your package manager or [directly from source](.travis.yml).
+You will need [CMake](https://cmake.org/) installed in order to build Box2D.
 
-If necessary, you can specify the Box2D header files location when compiling:
+Alternatively, you can supply your own installation of Box2D ([version 2.3.1](https://github.com/erincatto/Box2D/releases/tag/v2.3.1)) by pointing the `BOX2D_INCLUDE_PATH` environment variable to the Box2D header files. For example:
 
 ~~~~sh
 BOX2D_INCLUDE_PATH="path/to/Box2D/Box2D" cargo build
+~~~~
+
+In that case, the Box2D library must be available on rustc's library search path. If this is not the case, you can manually add it:
+
+~~~~sh
+RUSTFLAGS="-L path/to/Box2D/lib_dir"
 ~~~~

--- a/build.rs
+++ b/build.rs
@@ -1,19 +1,20 @@
-extern crate gcc;
-
-use std::env;
+extern crate cc;
+extern crate cmake;
 
 fn main() {
-    let mut config = gcc::Config::new();
-    let config = config
+    let box2d_install_prefix = cmake::Config::new("Box2D/Box2D")
+        .define("BOX2D_BUILD_STATIC", "ON")
+        .define("BOX2D_INSTALL", "ON")
+        .define("BOX2D_BUILD_SHARED", "OFF")
+        .define("BOX2D_BUILD_EXAMPLES", "OFF")
+        .define("BOX2D_INSTALL_DOC", "OFF")
+        .build();
+    println!("cargo:rustc-link-search=native={}/lib", box2d_install_prefix.display());
+    println!("cargo:rustc-link-lib=static=Box2D");
+
+    cc::Build::new()
         .cpp(true)
-        .file("frontend/lib.cpp");
-
-    let config = match env::var("BOX2D_INCLUDE_PATH") {
-        Ok(path) => config.include(path),
-        Err(_) => config
-    };
-
-    config.compile("libbox2d_frontend.a");
-
-    println!("cargo:rustc-flags=-l Box2D");
+        .include("Box2D/Box2D")
+        .file("frontend/lib.cpp")
+        .compile("libbox2d_frontend.a");
 }

--- a/build.rs
+++ b/build.rs
@@ -2,19 +2,25 @@ extern crate cc;
 extern crate cmake;
 
 fn main() {
-    let box2d_install_prefix = cmake::Config::new("Box2D/Box2D")
-        .define("BOX2D_BUILD_STATIC", "ON")
-        .define("BOX2D_INSTALL", "ON")
-        .define("BOX2D_BUILD_SHARED", "OFF")
-        .define("BOX2D_BUILD_EXAMPLES", "OFF")
-        .define("BOX2D_INSTALL_DOC", "OFF")
-        .build();
-    println!("cargo:rustc-link-search=native={}/lib", box2d_install_prefix.display());
-    println!("cargo:rustc-link-lib=static=Box2D");
+    let box2d_include_path = if let Some(path) = std::env::var("BOX2D_INCLUDE_PATH").ok() {
+        println!("cargo:rustc-flags=-l Box2D");
+        path
+    } else {
+        let box2d_install_prefix = cmake::Config::new("Box2D/Box2D")
+            .define("BOX2D_BUILD_STATIC", "ON")
+            .define("BOX2D_INSTALL", "ON")
+            .define("BOX2D_BUILD_SHARED", "OFF")
+            .define("BOX2D_BUILD_EXAMPLES", "OFF")
+            .define("BOX2D_INSTALL_DOC", "OFF")
+            .build();
+        println!("cargo:rustc-link-search=native={}/lib", box2d_install_prefix.display());
+        println!("cargo:rustc-link-lib=static=Box2D");
+        "Box2D/Box2D".to_owned()
+    };
 
     cc::Build::new()
         .cpp(true)
-        .include("Box2D/Box2D")
+        .include(box2d_include_path)
         .file("frontend/lib.cpp")
         .compile("libbox2d_frontend.a");
 }

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,9 @@ extern crate cc;
 extern crate cmake;
 
 fn main() {
-    if let Some(path) = std::env::var("BOX2D").ok() {
-        println!("cargo:rustc-flags=-l {}", path);
+    println!("cargo:rustc-link-lib=static=Box2D");
+    if let Some(path) = std::env::var("BOX2D_LIB_DIR").ok() {
+        println!("cargo:rustc-link-search=native={}", path);
     } else {
         let box2d_install_prefix = cmake::Config::new("Box2D/Box2D")
             .define("BOX2D_BUILD_STATIC", "ON")
@@ -13,7 +14,6 @@ fn main() {
             .define("BOX2D_INSTALL_DOC", "OFF")
             .build();
         println!("cargo:rustc-link-search=native={}/lib", box2d_install_prefix.display());
-        println!("cargo:rustc-link-lib=static=Box2D");
     };
 
     cc::Build::new()

--- a/build.rs
+++ b/build.rs
@@ -2,9 +2,8 @@ extern crate cc;
 extern crate cmake;
 
 fn main() {
-    let box2d_include_path = if let Some(path) = std::env::var("BOX2D_INCLUDE_PATH").ok() {
-        println!("cargo:rustc-flags=-l Box2D");
-        path
+    if let Some(path) = std::env::var("BOX2D").ok() {
+        println!("cargo:rustc-flags=-l {}", path);
     } else {
         let box2d_install_prefix = cmake::Config::new("Box2D/Box2D")
             .define("BOX2D_BUILD_STATIC", "ON")
@@ -15,12 +14,11 @@ fn main() {
             .build();
         println!("cargo:rustc-link-search=native={}/lib", box2d_install_prefix.display());
         println!("cargo:rustc-link-lib=static=Box2D");
-        "Box2D/Box2D".to_owned()
     };
 
     cc::Build::new()
         .cpp(true)
-        .include(box2d_include_path)
+        .include("Box2D/Box2D")
         .file("frontend/lib.cpp")
         .compile("libbox2d_frontend.a");
 }


### PR DESCRIPTION
Build and link Box2D as a Git submodule (pinned at version 2.3.1) in build.rs, not requiring users to have Box2D installed on their system. This significantly reduces the effort to use this library on Windows, since it does not have a package manager to install Box2D. This does require users to have CMake installed, because this is what Box2D uses as its build system.

Is this acceptable for merging, or would you rather have this as an optional feature?