### PR TITLE
Get rid of warnings and update bitflag code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrapped2d"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Thomas Koehler <basta.t.k+git@gmail.com>"]
 
 description = "Rust binding for Box2D"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ cmake = "^0.1"
 [dependencies]
 libc = "^0.2"
 vec_map = "^0.8"
-bitflags = "^0.9"
+bitflags = "^1.2.1"
 serde = { version = "^1.0", optional = true }
 serde_derive = { version = "^1.0", optional = true }
 cgmath = { version = "^0.14", optional = true }

--- a/src/collision/shapes/chain.rs
+++ b/src/collision/shapes/chain.rs
@@ -55,9 +55,9 @@ impl ChainShape {
 
     pub fn prev_vertex(&self) -> Option<Vec2> {
         unsafe {
-            let mut v = mem::uninitialized();
-            if ffi::ChainShape_get_prev_vertex(self.ptr(), &mut v) {
-                Some(v)
+            let mut v = mem::MaybeUninit::uninit();
+            if ffi::ChainShape_get_prev_vertex(self.ptr(), v.get_mut()) {
+                Some(v.assume_init())
             } else {
                 None
             }
@@ -71,9 +71,9 @@ impl ChainShape {
 
     pub fn next_vertex(&self) -> Option<Vec2> {
         unsafe {
-            let mut v = mem::uninitialized();
-            if ffi::ChainShape_get_next_vertex(self.ptr(), &mut v) {
-                Some(v)
+            let mut v = mem::MaybeUninit::uninit();
+            if ffi::ChainShape_get_next_vertex(self.ptr(), v.get_mut()) {
+                Some(v.assume_init())
             } else {
                 None
             }

--- a/src/collision/shapes/chain.rs
+++ b/src/collision/shapes/chain.rs
@@ -56,7 +56,7 @@ impl ChainShape {
     pub fn prev_vertex(&self) -> Option<Vec2> {
         unsafe {
             let mut v = mem::MaybeUninit::uninit();
-            if ffi::ChainShape_get_prev_vertex(self.ptr(), v.get_mut()) {
+            if ffi::ChainShape_get_prev_vertex(self.ptr(), &mut *v.as_mut_ptr()) {
                 Some(v.assume_init())
             } else {
                 None
@@ -72,7 +72,7 @@ impl ChainShape {
     pub fn next_vertex(&self) -> Option<Vec2> {
         unsafe {
             let mut v = mem::MaybeUninit::uninit();
-            if ffi::ChainShape_get_next_vertex(self.ptr(), v.get_mut()) {
+            if ffi::ChainShape_get_next_vertex(self.ptr(), &mut *v.as_mut_ptr()) {
                 Some(v.assume_init())
             } else {
                 None

--- a/src/collision/shapes/edge.rs
+++ b/src/collision/shapes/edge.rs
@@ -44,9 +44,9 @@ impl EdgeShape {
 
     pub fn v0(&self) -> Option<Vec2> {
         unsafe {
-            let mut v0 = mem::uninitialized();
-            if ffi::EdgeShape_get_v0(self.ptr(), &mut v0) {
-                Some(v0)
+            let mut v0 = mem::MaybeUninit::uninit();
+            if ffi::EdgeShape_get_v0(self.ptr(), v0.get_mut()) {
+                Some(v0.assume_init())
             } else {
                 None
             }
@@ -60,9 +60,9 @@ impl EdgeShape {
 
     pub fn v3(&self) -> Option<Vec2> {
         unsafe {
-            let mut v3 = mem::uninitialized();
-            if ffi::EdgeShape_get_v3(self.ptr(), &mut v3) {
-                Some(v3)
+            let mut v3 = mem::MaybeUninit::uninit();
+            if ffi::EdgeShape_get_v3(self.ptr(), v3.get_mut()) {
+                Some(v3.assume_init())
             } else {
                 None
             }

--- a/src/collision/shapes/edge.rs
+++ b/src/collision/shapes/edge.rs
@@ -45,7 +45,7 @@ impl EdgeShape {
     pub fn v0(&self) -> Option<Vec2> {
         unsafe {
             let mut v0 = mem::MaybeUninit::uninit();
-            if ffi::EdgeShape_get_v0(self.ptr(), v0.get_mut()) {
+            if ffi::EdgeShape_get_v0(self.ptr(), &mut *v0.as_mut_ptr()) {
                 Some(v0.assume_init())
             } else {
                 None
@@ -61,7 +61,7 @@ impl EdgeShape {
     pub fn v3(&self) -> Option<Vec2> {
         unsafe {
             let mut v3 = mem::MaybeUninit::uninit();
-            if ffi::EdgeShape_get_v3(self.ptr(), v3.get_mut()) {
+            if ffi::EdgeShape_get_v3(self.ptr(), &mut *v3.as_mut_ptr()) {
                 Some(v3.assume_init())
             } else {
                 None

--- a/src/dynamics/body.rs
+++ b/src/dynamics/body.rs
@@ -86,14 +86,14 @@ impl<U: UserDataTypes> MetaBody<U> {
         b
     }
 
-    pub fn create_fixture(&mut self, shape: &Shape, def: &mut FixtureDef) -> FixtureHandle
+    pub fn create_fixture(&mut self, shape: &dyn Shape, def: &mut FixtureDef) -> FixtureHandle
         where U::FixtureData: Default
     {
         self.create_fixture_with(shape, def, U::FixtureData::default())
     }
 
     pub fn create_fixture_with(&mut self,
-                               shape: &Shape,
+                               shape: &dyn Shape,
                                def: &mut FixtureDef,
                                data: U::FixtureData)
                                -> FixtureHandle {
@@ -104,14 +104,14 @@ impl<U: UserDataTypes> MetaBody<U> {
         }
     }
 
-    pub fn create_fast_fixture(&mut self, shape: &Shape, density: f32) -> FixtureHandle
+    pub fn create_fast_fixture(&mut self, shape: &dyn Shape, density: f32) -> FixtureHandle
         where U::FixtureData: Default
     {
         self.create_fast_fixture_with(shape, density, U::FixtureData::default())
     }
 
     pub fn create_fast_fixture_with(&mut self,
-                                    shape: &Shape,
+                                    shape: &dyn Shape,
                                     density: f32,
                                     data: U::FixtureData)
                                     -> FixtureHandle {
@@ -402,8 +402,6 @@ impl<'a> Iterator for JointIter<'a> {
     type Item = (BodyHandle, JointHandle);
     
     fn next(&mut self) -> Option<Self::Item> {
-        use user_data::RawUserData;
-        
         unsafe { match self.edge.as_ref() {
             None => None,
             Some(edge) => {
@@ -423,8 +421,6 @@ impl<'a> Iterator for ContactIter<'a> {
     type Item = (BodyHandle, WrappedRef<'a, Contact>);
     
     fn next(&mut self) -> Option<Self::Item> {
-        use user_data::RawUserData;
-        
         unsafe { match self.edge.as_ref() {
             None => None,
             Some(edge) => {
@@ -444,8 +440,6 @@ impl<'a> Iterator for ContactIterMut<'a> {
     type Item = (BodyHandle, WrappedRefMut<'a, Contact>);
     
     fn next(&mut self) -> Option<Self::Item> {
-        use user_data::RawUserData;
-        
         unsafe { match self.edge.as_mut() {
             None => None,
             Some(ref mut edge) => {

--- a/src/dynamics/contacts.rs
+++ b/src/dynamics/contacts.rs
@@ -29,9 +29,9 @@ impl Contact {
 
     pub fn world_manifold<'a>(&'a self) -> WorldManifold {
         unsafe {
-            let mut m = mem::uninitialized();
-            ffi::Contact_get_world_manifold(self.ptr(), &mut m);
-            m
+            let mut m = mem::MaybeUninit::uninit();
+            ffi::Contact_get_world_manifold(self.ptr(), m.as_mut_ptr());
+            m.assume_init()
         }
     }
 
@@ -101,9 +101,9 @@ impl Contact {
 
     pub fn evaluate(&mut self, xf_a: &Transform, xf_b: &Transform) -> Manifold {
         unsafe {
-            let mut m = mem::uninitialized();
-            ffi::Contact_evaluate_virtual(self.mut_ptr(), &mut m, xf_a, xf_b);
-            m
+            let mut m = mem::MaybeUninit::uninit();
+            ffi::Contact_evaluate_virtual(self.mut_ptr(), m.as_mut_ptr(), xf_a, xf_b);
+            m.assume_init()
         }
     }
 }

--- a/src/dynamics/joints/mod.rs
+++ b/src/dynamics/joints/mod.rs
@@ -82,7 +82,7 @@ pub trait JointDef {
 
 pub struct MetaJoint<U: UserDataTypes> {
     joint: UnknownJoint,
-    user_data: Box<InternalUserData<Joint, U::JointData>>,
+    user_data: Box<InternalUserData<dyn Joint, U::JointData>>,
 }
 
 impl<U: UserDataTypes> MetaJoint<U> {

--- a/src/dynamics/world.rs
+++ b/src/dynamics/world.rs
@@ -21,12 +21,12 @@ use self::callbacks::{ContactFilter, ContactFilterLink,
                       RayCastCallback, RayCastCallbackLink};
 
 pub type BodyHandle = TypedHandle<Body>;
-pub type JointHandle = TypedHandle<Joint>;
+pub type JointHandle = TypedHandle<dyn Joint>;
 
 pub struct World<U: UserDataTypes> {
     ptr: *mut ffi::World,
     bodies: HandleMap<MetaBody<U>, Body>,
-    joints: HandleMap<MetaJoint<U>, Joint>,
+    joints: HandleMap<MetaJoint<U>, dyn Joint>,
     contact_filter_link: ContactFilterLink,
     contact_listener_link: ContactListenerLink,
     draw_link: DrawLink,
@@ -105,7 +105,7 @@ impl<U: UserDataTypes> World<U> {
         self.bodies.iter()
     }
     
-    fn remove_body_joint_handles(body: &mut Body, joints: &mut HandleMap<MetaJoint<U>, Joint>) {
+    fn remove_body_joint_handles(body: &mut Body, joints: &mut HandleMap<MetaJoint<U>, dyn Joint>) {
         for (_, joint) in body.joints() {
             joints.remove(joint);
         }
@@ -139,7 +139,7 @@ impl<U: UserDataTypes> World<U> {
         }
     }
     
-    pub fn joints(&self) -> HandleIter<Joint, MetaJoint<U>> {
+    pub fn joints(&self) -> HandleIter<dyn Joint, MetaJoint<U>> {
         self.joints.iter()
     }
         

--- a/src/dynamics/world_callbacks.rs
+++ b/src/dynamics/world_callbacks.rs
@@ -20,7 +20,7 @@ pub trait ContactFilter<U: UserDataTypes>: Any {
 #[doc(hidden)]
 pub struct ContactFilterLink {
     ptr: *mut ffi::ContactFilterLink,
-    object: Option<Box<Any>>,
+    object: Option<Box<dyn Any>>,
 }
 
 wrap! { ffi::ContactFilterLink => custom ContactFilterLink }
@@ -81,7 +81,7 @@ pub trait ContactListener<U: UserDataTypes>: Any {
 #[doc(hidden)]
 pub struct ContactListenerLink {
     ptr: *mut ffi::ContactListenerLink,
-    object: Option<Box<Any>>,
+    object: Option<Box<dyn Any>>,
 }
 
 wrap! { ffi::ContactListenerLink => custom ContactListenerLink }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -2,6 +2,7 @@ use libc::c_void;
 use std::ptr;
 
 pub type Any = *mut c_void;
+#[allow(dead_code)]
 pub type ConstAny = *const c_void;
 
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(maybe_uninit_ref)]
 //! Bod2D for Rust
 //!
 //! You won't find a lot of information about Box2D itself here,
@@ -98,8 +99,7 @@ pub mod user_data;
 pub mod serialize;
 
 pub mod b2 {
-    pub use common::{Color, DrawFlags, Draw, DRAW_AABB, DRAW_CENTER_OF_MASS, DRAW_JOINT,
-                     DRAW_PAIR, DRAW_SHAPE};
+    pub use common::{Color, DrawFlags, Draw};
     pub use common::math::{Rot, Sweep, Transform, Vec2};
     pub use common::math::{cross_vv, cross_vs, cross_sv};
     pub use common::settings::{ANGULAR_SLOP, LINEAR_SLOP, MAX_MANIFOLD_POINTS,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(maybe_uninit_ref)]
 //! Bod2D for Rust
 //!
 //! You won't find a lot of information about Box2D itself here,

--- a/testbed/examples/apply_force.rs
+++ b/testbed/examples/apply_force.rs
@@ -40,10 +40,10 @@ fn main() {
             position: [0., 0.],
             size: [40., 40.]
         },
-        draw_flags: b2::DRAW_SHAPE |
-                    b2::DRAW_JOINT |
-                    b2::DRAW_PAIR |
-                    b2::DRAW_CENTER_OF_MASS
+        draw_flags: b2::DrawFlags::DRAW_SHAPE |
+                    b2::DrawFlags::DRAW_JOINT |
+                    b2::DrawFlags::DRAW_PAIR |
+                    b2::DrawFlags::DRAW_CENTER_OF_MASS
     };
 
     testbed::run(process_input, data, "Apply Force", 400, 400);

--- a/testbed/examples/basic_slider_crank.rs
+++ b/testbed/examples/basic_slider_crank.rs
@@ -20,10 +20,10 @@ fn main() {
             position: [0., 20.],
             size: [40., 40.]
         },
-        draw_flags: b2::DRAW_SHAPE |
-                    b2::DRAW_JOINT |
-                    b2::DRAW_PAIR |
-                    b2::DRAW_CENTER_OF_MASS
+        draw_flags: b2::DrawFlags::DRAW_SHAPE |
+                    b2::DrawFlags::DRAW_JOINT |
+                    b2::DrawFlags::DRAW_PAIR |
+                    b2::DrawFlags::DRAW_CENTER_OF_MASS
     };
 
     testbed::run((), data, "Basic Slider Crank", 400, 400);

--- a/testbed/examples/breakable.rs
+++ b/testbed/examples/breakable.rs
@@ -19,11 +19,11 @@ fn main() {
             position: [0., 10.],
             size: [40., 40.]
         },
-        draw_flags: b2::DRAW_SHAPE |
-                    b2::DRAW_AABB |
-                    b2::DRAW_JOINT |
-                    b2::DRAW_PAIR |
-                    b2::DRAW_CENTER_OF_MASS
+        draw_flags: b2::DrawFlags::DRAW_SHAPE |
+                    b2::DrawFlags::DRAW_AABB |
+                    b2::DrawFlags::DRAW_JOINT |
+                    b2::DrawFlags::DRAW_PAIR |
+                    b2::DrawFlags::DRAW_CENTER_OF_MASS
     };
 
     testbed::run(test, data, "Breakable", 400, 400);

--- a/testbed/examples/simple.rs
+++ b/testbed/examples/simple.rs
@@ -69,11 +69,11 @@ fn main() {
             position: [0., 5.],
             size: [40., 40.]
         },
-        draw_flags: b2::DRAW_SHAPE |
-                    b2::DRAW_AABB |
-                    b2::DRAW_JOINT |
-                    b2::DRAW_PAIR |
-                    b2::DRAW_CENTER_OF_MASS
+        draw_flags: b2::DrawFlags::DRAW_SHAPE |
+                    b2::DrawFlags::DRAW_AABB |
+                    b2::DrawFlags::DRAW_JOINT |
+                    b2::DrawFlags::DRAW_PAIR |
+                    b2::DrawFlags::DRAW_CENTER_OF_MASS
     };
 
     testbed::run(process_input, data, "Simple", 400, 400);

--- a/testbed/examples/web.rs
+++ b/testbed/examples/web.rs
@@ -37,11 +37,11 @@ fn main() {
             position: [0., 10.],
             size: [40., 40.]
         },
-        draw_flags: b2::DRAW_SHAPE |
-                    b2::DRAW_AABB |
-                    b2::DRAW_JOINT |
-                    b2::DRAW_PAIR |
-                    b2::DRAW_CENTER_OF_MASS
+        draw_flags: b2::DrawFlags::DRAW_SHAPE |
+                    b2::DrawFlags::DRAW_AABB |
+                    b2::DrawFlags::DRAW_JOINT |
+                    b2::DrawFlags::DRAW_PAIR |
+                    b2::DrawFlags::DRAW_CENTER_OF_MASS
     };
 
     testbed::run(process_input, data, "Web", 400, 400);


### PR DESCRIPTION
Currently, building the code produces a ton of warnings which can easily be fixed. So I took the time to fix all the warnings and make the code a bit more idiomatic and compliant with the current version of Rust. I also updated the bitflag code to use version `1.2.1` instead of `0.9` to fix several warnings.

Note: I had to add an unstable feature to make the code work. If there's a better way to do it, let me know.