### PR TITLE
Added try variants of body/fixture/joint getters

### DIFF
--- a/src/dynamics/body.rs
+++ b/src/dynamics/body.rs
@@ -129,6 +129,14 @@ impl<U: UserDataTypes> MetaBody<U> {
         self.fixtures.get_mut(handle).expect("invalid fixture handle")
     }
 
+    pub fn try_fixture(&self, handle: FixtureHandle) -> Option<Ref<MetaFixture<U>>> {
+        self.fixtures.get(handle)
+    }
+
+    pub fn try_fixture_mut(&self, handle: FixtureHandle) -> Option<RefMut<MetaFixture<U>>> {
+        self.fixtures.get_mut(handle)
+    }
+
     pub fn destroy_fixture(&mut self, handle: FixtureHandle) {
         let mut fixture = self.fixtures.remove(handle);
         unsafe {

--- a/src/dynamics/joints/distance.rs
+++ b/src/dynamics/joints/distance.rs
@@ -43,6 +43,22 @@ impl DistanceJointDef {
         self.local_anchor_b = b.local_point(anchor_b);
         self.length = (anchor_b - anchor_a).norm();
     }
+
+    pub fn try_init<U: UserDataTypes>(&mut self,
+                                      world: &World<U>,
+                                      body_a: BodyHandle,
+                                      body_b: BodyHandle,
+                                      anchor_a: &Vec2,
+                                      anchor_b: &Vec2) -> Option<()> {
+        self.body_a = body_a;
+        self.body_b = body_b;
+        let a = world.try_body_mut(body_a)?;
+        let b = world.try_body_mut(body_b)?;
+        self.local_anchor_a = a.local_point(anchor_a);
+        self.local_anchor_b = b.local_point(anchor_b);
+        self.length = (anchor_b - anchor_a).norm();
+        Some(())
+    }
 }
 
 impl JointDef for DistanceJointDef {

--- a/src/dynamics/joints/distance.rs
+++ b/src/dynamics/joints/distance.rs
@@ -35,13 +35,7 @@ impl DistanceJointDef {
                                   body_b: BodyHandle,
                                   anchor_a: &Vec2,
                                   anchor_b: &Vec2) {
-        self.body_a = body_a;
-        self.body_b = body_b;
-        let a = world.body(body_a);
-        let b = world.body(body_b);
-        self.local_anchor_a = a.local_point(anchor_a);
-        self.local_anchor_b = b.local_point(anchor_b);
-        self.length = (anchor_b - anchor_a).norm();
+        self.try_init(world, body_a, body_b, anchor_a, anchor_b).expect("joint init filed: invalid body handle");
     }
 
     pub fn try_init<U: UserDataTypes>(&mut self,
@@ -69,15 +63,7 @@ impl JointDef for DistanceJointDef {
     }
 
     unsafe fn create<U: UserDataTypes>(&self, world: &mut World<U>) -> *mut ffi::Joint {
-        ffi::World_create_distance_joint(world.mut_ptr(),
-                                         world.body_mut(self.body_a).mut_ptr(),
-                                         world.body_mut(self.body_b).mut_ptr(),
-                                         self.collide_connected,
-                                         self.local_anchor_a,
-                                         self.local_anchor_b,
-                                         self.length,
-                                         self.frequency,
-                                         self.damping_ratio)
+        self.try_create(world).expect("joint create failed: invalid body handle")
     }
 
     unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {

--- a/src/dynamics/joints/distance.rs
+++ b/src/dynamics/joints/distance.rs
@@ -52,8 +52,8 @@ impl DistanceJointDef {
                                       anchor_b: &Vec2) -> Option<()> {
         self.body_a = body_a;
         self.body_b = body_b;
-        let a = world.try_body_mut(body_a)?;
-        let b = world.try_body_mut(body_b)?;
+        let a = world.try_body(body_a)?;
+        let b = world.try_body(body_b)?;
         self.local_anchor_a = a.local_point(anchor_a);
         self.local_anchor_b = b.local_point(anchor_b);
         self.length = (anchor_b - anchor_a).norm();
@@ -78,6 +78,18 @@ impl JointDef for DistanceJointDef {
                                          self.length,
                                          self.frequency,
                                          self.damping_ratio)
+    }
+
+    unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {
+        Some(ffi::World_create_distance_joint(world.mut_ptr(),
+                                              world.try_body_mut(self.body_a)?.mut_ptr(),
+                                              world.try_body_mut(self.body_b)?.mut_ptr(),
+                                              self.collide_connected,
+                                              self.local_anchor_a,
+                                              self.local_anchor_b,
+                                              self.length,
+                                              self.frequency,
+                                              self.damping_ratio))
     }
 }
 

--- a/src/dynamics/joints/friction.rs
+++ b/src/dynamics/joints/friction.rs
@@ -47,8 +47,8 @@ impl FrictionJointDef {
                                       anchor: &Vec2) -> Option<()> {
         self.body_a = body_a;
         self.body_b = body_b;
-        let a = world.try_body_mut(body_a)?;
-        let b = world.try_body_mut(body_b)?;
+        let a = world.try_body(body_a)?;
+        let b = world.try_body(body_b)?;
         self.local_anchor_a = a.local_point(anchor);
         self.local_anchor_b = b.local_point(anchor);
         Some(())

--- a/src/dynamics/joints/friction.rs
+++ b/src/dynamics/joints/friction.rs
@@ -32,12 +32,7 @@ impl FrictionJointDef {
                                   body_a: BodyHandle,
                                   body_b: BodyHandle,
                                   anchor: &Vec2) {
-        self.body_a = body_a;
-        self.body_b = body_b;
-        let a = world.body(body_a);
-        let b = world.body(body_b);
-        self.local_anchor_a = a.local_point(anchor);
-        self.local_anchor_b = b.local_point(anchor);
+        self.try_init(world, body_a, body_b, anchor).expect("joint init filed: invalid body handle");
     }
 
     pub fn try_init<U: UserDataTypes>(&mut self,
@@ -63,14 +58,7 @@ impl JointDef for FrictionJointDef {
     }
 
     unsafe fn create<U: UserDataTypes>(&self, world: &mut World<U>) -> *mut ffi::Joint {
-        ffi::World_create_friction_joint(world.mut_ptr(),
-                                         world.body_mut(self.body_a).mut_ptr(),
-                                         world.body_mut(self.body_b).mut_ptr(),
-                                         self.collide_connected,
-                                         self.local_anchor_a,
-                                         self.local_anchor_b,
-                                         self.max_force,
-                                         self.max_torque)
+        self.try_create(world).expect("joint create failed: invalid body handle")
     }
 
     unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {

--- a/src/dynamics/joints/friction.rs
+++ b/src/dynamics/joints/friction.rs
@@ -39,6 +39,20 @@ impl FrictionJointDef {
         self.local_anchor_a = a.local_point(anchor);
         self.local_anchor_b = b.local_point(anchor);
     }
+
+    pub fn try_init<U: UserDataTypes>(&mut self,
+                                      world: &World<U>,
+                                      body_a: BodyHandle,
+                                      body_b: BodyHandle,
+                                      anchor: &Vec2) -> Option<()> {
+        self.body_a = body_a;
+        self.body_b = body_b;
+        let a = world.try_body_mut(body_a)?;
+        let b = world.try_body_mut(body_b)?;
+        self.local_anchor_a = a.local_point(anchor);
+        self.local_anchor_b = b.local_point(anchor);
+        Some(())
+    }
 }
 
 impl JointDef for FrictionJointDef {

--- a/src/dynamics/joints/friction.rs
+++ b/src/dynamics/joints/friction.rs
@@ -72,6 +72,17 @@ impl JointDef for FrictionJointDef {
                                          self.max_force,
                                          self.max_torque)
     }
+
+    unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {
+        Some(ffi::World_create_friction_joint(world.mut_ptr(),
+                                              world.try_body_mut(self.body_a)?.mut_ptr(),
+                                              world.try_body_mut(self.body_b)?.mut_ptr(),
+                                              self.collide_connected,
+                                              self.local_anchor_a,
+                                              self.local_anchor_b,
+                                              self.max_force,
+                                              self.max_torque))
+    }
 }
 
 wrap_joint! {

--- a/src/dynamics/joints/gear.rs
+++ b/src/dynamics/joints/gear.rs
@@ -19,6 +19,24 @@ impl GearJointDef {
             ratio: 1.,
         }
     }
+    
+    pub fn init<U: UserDataTypes>(&mut self,
+                                  joint_1: JointHandle,
+                                  joint_2: JointHandle) {
+        self.joint_1 = joint_1;
+        self.joint_2 = joint_2;
+    }
+
+    pub fn try_init<U: UserDataTypes>(&mut self,
+                                      world: &World<U>,
+                                      joint_1: JointHandle,
+                                      joint_2: JointHandle) -> Option<()> {
+        self.joint_1 = joint_1;
+        self.joint_2 = joint_2;
+        world.try_joint_mut(joint_1)?;
+        world.try_joint_mut(joint_2)?;
+        Some(())
+    }
 }
 
 impl JointDef for GearJointDef {

--- a/src/dynamics/joints/gear.rs
+++ b/src/dynamics/joints/gear.rs
@@ -29,11 +29,7 @@ impl JointDef for GearJointDef {
     }
 
     unsafe fn create<U: UserDataTypes>(&self, world: &mut World<U>) -> *mut ffi::Joint {
-        ffi::World_create_gear_joint(world.mut_ptr(),
-                                     self.collide_connected,
-                                     world.joint_mut(self.joint_1).mut_base_ptr(),
-                                     world.joint_mut(self.joint_2).mut_base_ptr(),
-                                     self.ratio)
+        self.try_create(world).expect("joint create failed: invalid joint handle")
     }
 
     unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {

--- a/src/dynamics/joints/gear.rs
+++ b/src/dynamics/joints/gear.rs
@@ -19,24 +19,6 @@ impl GearJointDef {
             ratio: 1.,
         }
     }
-    
-    pub fn init<U: UserDataTypes>(&mut self,
-                                  joint_1: JointHandle,
-                                  joint_2: JointHandle) {
-        self.joint_1 = joint_1;
-        self.joint_2 = joint_2;
-    }
-
-    pub fn try_init<U: UserDataTypes>(&mut self,
-                                      world: &World<U>,
-                                      joint_1: JointHandle,
-                                      joint_2: JointHandle) -> Option<()> {
-        self.joint_1 = joint_1;
-        self.joint_2 = joint_2;
-        world.try_joint_mut(joint_1)?;
-        world.try_joint_mut(joint_2)?;
-        Some(())
-    }
 }
 
 impl JointDef for GearJointDef {
@@ -52,6 +34,14 @@ impl JointDef for GearJointDef {
                                      world.joint_mut(self.joint_1).mut_base_ptr(),
                                      world.joint_mut(self.joint_2).mut_base_ptr(),
                                      self.ratio)
+    }
+
+    unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {
+        Some(ffi::World_create_gear_joint(world.mut_ptr(),
+                                          self.collide_connected,
+                                          world.try_joint_mut(self.joint_1)?.mut_base_ptr(),
+                                          world.try_joint_mut(self.joint_2)?.mut_base_ptr(),
+                                          self.ratio))
     }
 }
 

--- a/src/dynamics/joints/mod.rs
+++ b/src/dynamics/joints/mod.rs
@@ -78,6 +78,11 @@ pub trait JointDef {
 
     #[doc(hidden)]
     unsafe fn create<U: UserDataTypes>(&self, world: &mut World<U>) -> *mut ffi::Joint;
+    
+    #[doc(hidden)]
+    unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {
+        Some(self.create(world))
+    }
 }
 
 pub struct MetaJoint<U: UserDataTypes> {

--- a/src/dynamics/joints/motor.rs
+++ b/src/dynamics/joints/motor.rs
@@ -33,12 +33,7 @@ impl MotorJointDef {
                                   world: &World<U>,
                                   body_a: BodyHandle,
                                   body_b: BodyHandle) {
-        self.body_a = body_a;
-        self.body_b = body_b;
-        let a = world.body(body_a);
-        let b = world.body(body_b);
-        self.linear_offset = a.local_point(b.position());
-        self.angular_offset = b.angle() - a.angle();
+        self.try_init(world, body_a, body_b).expect("joint init filed: invalid body handle");
     }
 
     pub fn try_init<U: UserDataTypes>(&mut self,
@@ -63,15 +58,7 @@ impl JointDef for MotorJointDef {
     }
 
     unsafe fn create<U: UserDataTypes>(&self, world: &mut World<U>) -> *mut ffi::Joint {
-        ffi::World_create_motor_joint(world.mut_ptr(),
-                                      world.body_mut(self.body_a).mut_ptr(),
-                                      world.body_mut(self.body_b).mut_ptr(),
-                                      self.collide_connected,
-                                      self.linear_offset,
-                                      self.angular_offset,
-                                      self.max_force,
-                                      self.max_torque,
-                                      self.correction_factor)
+        self.try_create(world).expect("joint create failed: invalid body handle")
     }
 
     unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {

--- a/src/dynamics/joints/motor.rs
+++ b/src/dynamics/joints/motor.rs
@@ -40,6 +40,19 @@ impl MotorJointDef {
         self.linear_offset = a.local_point(b.position());
         self.angular_offset = b.angle() - a.angle();
     }
+
+    pub fn try_init<U: UserDataTypes>(&mut self,
+                                      world: &World<U>,
+                                      body_a: BodyHandle,
+                                      body_b: BodyHandle) -> Option<()> {
+        self.body_a = body_a;
+        self.body_b = body_b;
+        let a = world.try_body_mut(body_a)?;
+        let b = world.try_body_mut(body_b)?;
+        self.linear_offset = a.local_point(b.position());
+        self.angular_offset = b.angle() - a.angle();
+        Some(())
+    }
 }
 
 impl JointDef for MotorJointDef {

--- a/src/dynamics/joints/motor.rs
+++ b/src/dynamics/joints/motor.rs
@@ -47,8 +47,8 @@ impl MotorJointDef {
                                       body_b: BodyHandle) -> Option<()> {
         self.body_a = body_a;
         self.body_b = body_b;
-        let a = world.try_body_mut(body_a)?;
-        let b = world.try_body_mut(body_b)?;
+        let a = world.try_body(body_a)?;
+        let b = world.try_body(body_b)?;
         self.linear_offset = a.local_point(b.position());
         self.angular_offset = b.angle() - a.angle();
         Some(())
@@ -72,6 +72,18 @@ impl JointDef for MotorJointDef {
                                       self.max_force,
                                       self.max_torque,
                                       self.correction_factor)
+    }
+
+    unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {
+        Some(ffi::World_create_motor_joint(world.mut_ptr(),
+                                           world.try_body_mut(self.body_a)?.mut_ptr(),
+                                           world.try_body_mut(self.body_b)?.mut_ptr(),
+                                           self.collide_connected,
+                                           self.linear_offset,
+                                           self.angular_offset,
+                                           self.max_force,
+                                           self.max_torque,
+                                           self.correction_factor))
     }
 }
 

--- a/src/dynamics/joints/mouse.rs
+++ b/src/dynamics/joints/mouse.rs
@@ -26,6 +26,24 @@ impl MouseJointDef {
             damping_ratio: 0.7,
         }
     }
+    
+    pub fn init<U: UserDataTypes>(&mut self,
+                                  body_a: BodyHandle,
+                                  body_b: BodyHandle) {
+        self.body_a = body_a;
+        self.body_b = body_b;
+    }
+
+    pub fn try_init<U: UserDataTypes>(&mut self,
+                                      world: &World<U>,
+                                      body_a: BodyHandle,
+                                      body_b: BodyHandle) -> Option<()> {
+        self.body_a = body_a;
+        self.body_b = body_b;
+        world.try_body_mut(body_a)?;
+        world.try_body_mut(body_b)?;
+        Some(())
+    }
 }
 
 impl JointDef for MouseJointDef {

--- a/src/dynamics/joints/mouse.rs
+++ b/src/dynamics/joints/mouse.rs
@@ -26,24 +26,6 @@ impl MouseJointDef {
             damping_ratio: 0.7,
         }
     }
-    
-    pub fn init<U: UserDataTypes>(&mut self,
-                                  body_a: BodyHandle,
-                                  body_b: BodyHandle) {
-        self.body_a = body_a;
-        self.body_b = body_b;
-    }
-
-    pub fn try_init<U: UserDataTypes>(&mut self,
-                                      world: &World<U>,
-                                      body_a: BodyHandle,
-                                      body_b: BodyHandle) -> Option<()> {
-        self.body_a = body_a;
-        self.body_b = body_b;
-        world.try_body_mut(body_a)?;
-        world.try_body_mut(body_b)?;
-        Some(())
-    }
 }
 
 impl JointDef for MouseJointDef {
@@ -62,6 +44,17 @@ impl JointDef for MouseJointDef {
                                       self.max_force,
                                       self.frequency,
                                       self.damping_ratio)
+    }
+
+    unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {
+        Some(ffi::World_create_mouse_joint(world.mut_ptr(),
+                                           world.try_body_mut(self.body_a)?.mut_ptr(),
+                                           world.try_body_mut(self.body_b)?.mut_ptr(),
+                                           self.collide_connected,
+                                           self.target,
+                                           self.max_force,
+                                           self.frequency,
+                                           self.damping_ratio))
     }
 }
 

--- a/src/dynamics/joints/mouse.rs
+++ b/src/dynamics/joints/mouse.rs
@@ -36,14 +36,7 @@ impl JointDef for MouseJointDef {
     }
 
     unsafe fn create<U: UserDataTypes>(&self, world: &mut World<U>) -> *mut ffi::Joint {
-        ffi::World_create_mouse_joint(world.mut_ptr(),
-                                      world.body_mut(self.body_a).mut_ptr(),
-                                      world.body_mut(self.body_b).mut_ptr(),
-                                      self.collide_connected,
-                                      self.target,
-                                      self.max_force,
-                                      self.frequency,
-                                      self.damping_ratio)
+        self.try_create(world).expect("joint create failed: invalid body handle")
     }
 
     unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {

--- a/src/dynamics/joints/prismatic.rs
+++ b/src/dynamics/joints/prismatic.rs
@@ -63,8 +63,8 @@ impl PrismaticJointDef {
                                       axis: &Vec2) -> Option<()> {
         self.body_a = body_a;
         self.body_b = body_b;
-        let a = world.try_body_mut(body_a)?;
-        let b = world.try_body_mut(body_b)?;
+        let a = world.try_body(body_a)?;
+        let b = world.try_body(body_b)?;
         self.local_anchor_a = a.local_point(anchor);
         self.local_anchor_b = b.local_point(anchor);
         self.local_axis_a = a.local_vector(axis);
@@ -95,6 +95,23 @@ impl JointDef for PrismaticJointDef {
                                           self.enable_motor,
                                           self.max_motor_force,
                                           self.motor_speed)
+    }
+
+    unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {
+        Some(ffi::World_create_prismatic_joint(world.mut_ptr(),
+                                               world.try_body_mut(self.body_a)?.mut_ptr(),
+                                               world.try_body_mut(self.body_b)?.mut_ptr(),
+                                               self.collide_connected,
+                                               self.local_anchor_a,
+                                               self.local_anchor_b,
+                                               self.local_axis_a,
+                                               self.reference_angle,
+                                               self.enable_limit,
+                                               self.lower_translation,
+                                               self.upper_translation,
+                                               self.enable_motor,
+                                               self.max_motor_force,
+                                               self.motor_speed))
     }
 }
 

--- a/src/dynamics/joints/prismatic.rs
+++ b/src/dynamics/joints/prismatic.rs
@@ -54,6 +54,23 @@ impl PrismaticJointDef {
         self.local_axis_a = a.local_vector(axis);
         self.reference_angle = b.angle() - a.angle();
     }
+
+    pub fn try_init<U: UserDataTypes>(&mut self,
+                                      world: &World<U>,
+                                      body_a: BodyHandle,
+                                      body_b: BodyHandle,
+                                      anchor: &Vec2,
+                                      axis: &Vec2) -> Option<()> {
+        self.body_a = body_a;
+        self.body_b = body_b;
+        let a = world.try_body_mut(body_a)?;
+        let b = world.try_body_mut(body_b)?;
+        self.local_anchor_a = a.local_point(anchor);
+        self.local_anchor_b = b.local_point(anchor);
+        self.local_axis_a = a.local_vector(axis);
+        self.reference_angle = b.angle() - a.angle();
+        Some(())
+    }
 }
 
 impl JointDef for PrismaticJointDef {

--- a/src/dynamics/joints/prismatic.rs
+++ b/src/dynamics/joints/prismatic.rs
@@ -45,14 +45,7 @@ impl PrismaticJointDef {
                                   body_b: BodyHandle,
                                   anchor: &Vec2,
                                   axis: &Vec2) {
-        self.body_a = body_a;
-        self.body_b = body_b;
-        let a = world.body(body_a);
-        let b = world.body(body_b);
-        self.local_anchor_a = a.local_point(anchor);
-        self.local_anchor_b = b.local_point(anchor);
-        self.local_axis_a = a.local_vector(axis);
-        self.reference_angle = b.angle() - a.angle();
+        self.try_init(world, body_a, body_b, anchor, axis).expect("joint init filed: invalid body handle");
     }
 
     pub fn try_init<U: UserDataTypes>(&mut self,
@@ -81,20 +74,7 @@ impl JointDef for PrismaticJointDef {
     }
 
     unsafe fn create<U: UserDataTypes>(&self, world: &mut World<U>) -> *mut ffi::Joint {
-        ffi::World_create_prismatic_joint(world.mut_ptr(),
-                                          world.body_mut(self.body_a).mut_ptr(),
-                                          world.body_mut(self.body_b).mut_ptr(),
-                                          self.collide_connected,
-                                          self.local_anchor_a,
-                                          self.local_anchor_b,
-                                          self.local_axis_a,
-                                          self.reference_angle,
-                                          self.enable_limit,
-                                          self.lower_translation,
-                                          self.upper_translation,
-                                          self.enable_motor,
-                                          self.max_motor_force,
-                                          self.motor_speed)
+        self.try_create(world).expect("joint create failed: invalid body handle")
     }
 
     unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {

--- a/src/dynamics/joints/pulley.rs
+++ b/src/dynamics/joints/pulley.rs
@@ -60,17 +60,7 @@ impl JointDef for PulleyJointDef {
     }
 
     unsafe fn create<U: UserDataTypes>(&self, world: &mut World<U>) -> *mut ffi::Joint {
-        ffi::World_create_pulley_joint(world.mut_ptr(),
-                                       world.body_mut(self.body_a).mut_ptr(),
-                                       world.body_mut(self.body_b).mut_ptr(),
-                                       self.collide_connected,
-                                       self.ground_anchor_a,
-                                       self.ground_anchor_b,
-                                       self.local_anchor_a,
-                                       self.local_anchor_b,
-                                       self.length_a,
-                                       self.length_b,
-                                       self.ratio)
+        self.try_create(world).expect("joint create failed: invalid body handle")
     }
 
     unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {

--- a/src/dynamics/joints/pulley.rs
+++ b/src/dynamics/joints/pulley.rs
@@ -50,28 +50,6 @@ impl PulleyJointDef {
         self.length_b = (anchor_b - ground_b).norm();
         self.ratio = ratio;
     }
-
-    pub fn try_init<U: UserDataTypes>(&mut self,
-                                     world: &World<U>,
-                                     body_a: BodyHandle,
-                                     body_b: BodyHandle,
-                                     ground_a: Vec2,
-                                     ground_b: Vec2,
-                                     anchor_a: &Vec2,
-                                     anchor_b: &Vec2,
-                                     ratio: f32) -> Option<()> {
-        assert!(ratio > ::std::f32::EPSILON);
-        self.body_a = body_a;
-        self.body_b = body_b;
-        self.ground_anchor_a = ground_a;
-        self.ground_anchor_b = ground_b;
-        self.length_a = (anchor_a - ground_a).norm();
-        self.length_b = (anchor_b - ground_b).norm();
-        self.ratio = ratio;
-        world.try_body_mut(body_a)?;
-        world.try_body_mut(body_b)?;
-        Some(())
-    }
 }
 
 impl JointDef for PulleyJointDef {
@@ -93,6 +71,20 @@ impl JointDef for PulleyJointDef {
                                        self.length_a,
                                        self.length_b,
                                        self.ratio)
+    }
+
+    unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {
+        Some(ffi::World_create_pulley_joint(world.mut_ptr(),
+                                            world.try_body_mut(self.body_a)?.mut_ptr(),
+                                            world.try_body_mut(self.body_b)?.mut_ptr(),
+                                            self.collide_connected,
+                                            self.ground_anchor_a,
+                                            self.ground_anchor_b,
+                                            self.local_anchor_a,
+                                            self.local_anchor_b,
+                                            self.length_a,
+                                            self.length_b,
+                                            self.ratio))
     }
 }
 

--- a/src/dynamics/joints/pulley.rs
+++ b/src/dynamics/joints/pulley.rs
@@ -50,6 +50,28 @@ impl PulleyJointDef {
         self.length_b = (anchor_b - ground_b).norm();
         self.ratio = ratio;
     }
+
+    pub fn try_init<U: UserDataTypes>(&mut self,
+                                     world: &World<U>,
+                                     body_a: BodyHandle,
+                                     body_b: BodyHandle,
+                                     ground_a: Vec2,
+                                     ground_b: Vec2,
+                                     anchor_a: &Vec2,
+                                     anchor_b: &Vec2,
+                                     ratio: f32) -> Option<()> {
+        assert!(ratio > ::std::f32::EPSILON);
+        self.body_a = body_a;
+        self.body_b = body_b;
+        self.ground_anchor_a = ground_a;
+        self.ground_anchor_b = ground_b;
+        self.length_a = (anchor_a - ground_a).norm();
+        self.length_b = (anchor_b - ground_b).norm();
+        self.ratio = ratio;
+        world.try_body_mut(body_a)?;
+        world.try_body_mut(body_b)?;
+        Some(())
+    }
 }
 
 impl JointDef for PulleyJointDef {

--- a/src/dynamics/joints/revolute.rs
+++ b/src/dynamics/joints/revolute.rs
@@ -50,6 +50,21 @@ impl RevoluteJointDef {
         self.local_anchor_b = b.local_point(anchor);
         self.reference_angle = b.angle() - a.angle();
     }
+
+    pub fn try_init<U: UserDataTypes>(&mut self,
+                                      world: &World<U>,
+                                      body_a: BodyHandle,
+                                      body_b: BodyHandle,
+                                      anchor: &Vec2) -> Option<()> {
+        self.body_a = body_a;
+        self.body_b = body_b;
+        let a = world.try_body_mut(body_a)?;
+        let b = world.try_body_mut(body_b)?;
+        self.local_anchor_a = a.local_point(anchor);
+        self.local_anchor_b = b.local_point(anchor);
+        self.reference_angle = b.angle() - a.angle();
+        Some(())
+    }
 }
 
 impl JointDef for RevoluteJointDef {

--- a/src/dynamics/joints/revolute.rs
+++ b/src/dynamics/joints/revolute.rs
@@ -42,13 +42,7 @@ impl RevoluteJointDef {
                                   body_a: BodyHandle,
                                   body_b: BodyHandle,
                                   anchor: &Vec2) {
-        self.body_a = body_a;
-        self.body_b = body_b;
-        let a = world.body(body_a);
-        let b = world.body(body_b);
-        self.local_anchor_a = a.local_point(anchor);
-        self.local_anchor_b = b.local_point(anchor);
-        self.reference_angle = b.angle() - a.angle();
+        self.try_init(world, body_a, body_b, anchor).expect("joint init filed: invalid body handle");
     }
 
     pub fn try_init<U: UserDataTypes>(&mut self,
@@ -75,19 +69,7 @@ impl JointDef for RevoluteJointDef {
     }
 
     unsafe fn create<U: UserDataTypes>(&self, world: &mut World<U>) -> *mut ffi::Joint {
-        ffi::World_create_revolute_joint(world.mut_ptr(),
-                                         world.body_mut(self.body_a).mut_ptr(),
-                                         world.body_mut(self.body_b).mut_ptr(),
-                                         self.collide_connected,
-                                         self.local_anchor_a,
-                                         self.local_anchor_b,
-                                         self.reference_angle,
-                                         self.enable_limit,
-                                         self.lower_angle,
-                                         self.upper_angle,
-                                         self.enable_motor,
-                                         self.motor_speed,
-                                         self.max_motor_torque)
+        self.try_create(world).expect("joint create failed: invalid body handle")
     }
 
     unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {

--- a/src/dynamics/joints/revolute.rs
+++ b/src/dynamics/joints/revolute.rs
@@ -58,8 +58,8 @@ impl RevoluteJointDef {
                                       anchor: &Vec2) -> Option<()> {
         self.body_a = body_a;
         self.body_b = body_b;
-        let a = world.try_body_mut(body_a)?;
-        let b = world.try_body_mut(body_b)?;
+        let a = world.try_body(body_a)?;
+        let b = world.try_body(body_b)?;
         self.local_anchor_a = a.local_point(anchor);
         self.local_anchor_b = b.local_point(anchor);
         self.reference_angle = b.angle() - a.angle();
@@ -88,6 +88,22 @@ impl JointDef for RevoluteJointDef {
                                          self.enable_motor,
                                          self.motor_speed,
                                          self.max_motor_torque)
+    }
+
+    unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {
+        Some(ffi::World_create_revolute_joint(world.mut_ptr(),
+                                              world.try_body_mut(self.body_a)?.mut_ptr(),
+                                              world.try_body_mut(self.body_b)?.mut_ptr(),
+                                              self.collide_connected,
+                                              self.local_anchor_a,
+                                              self.local_anchor_b,
+                                              self.reference_angle,
+                                              self.enable_limit,
+                                              self.lower_angle,
+                                              self.upper_angle,
+                                              self.enable_motor,
+                                              self.motor_speed,
+                                              self.max_motor_torque))
     }
 }
 

--- a/src/dynamics/joints/rope.rs
+++ b/src/dynamics/joints/rope.rs
@@ -24,6 +24,24 @@ impl RopeJointDef {
             max_length: 0.,
         }
     }
+    
+    pub fn init<U: UserDataTypes>(&mut self,
+                                  body_a: BodyHandle,
+                                  body_b: BodyHandle) {
+        self.body_a = body_a;
+        self.body_b = body_b;
+    }
+
+    pub fn try_init<U: UserDataTypes>(&mut self,
+                                      world: &World<U>,
+                                      body_a: BodyHandle,
+                                      body_b: BodyHandle) -> Option<()> {
+        self.body_a = body_a;
+        self.body_b = body_b;
+        world.try_body_mut(body_a)?;
+        world.try_body_mut(body_b)?;
+        Some(())
+    }
 }
 
 impl JointDef for RopeJointDef {

--- a/src/dynamics/joints/rope.rs
+++ b/src/dynamics/joints/rope.rs
@@ -24,24 +24,6 @@ impl RopeJointDef {
             max_length: 0.,
         }
     }
-    
-    pub fn init<U: UserDataTypes>(&mut self,
-                                  body_a: BodyHandle,
-                                  body_b: BodyHandle) {
-        self.body_a = body_a;
-        self.body_b = body_b;
-    }
-
-    pub fn try_init<U: UserDataTypes>(&mut self,
-                                      world: &World<U>,
-                                      body_a: BodyHandle,
-                                      body_b: BodyHandle) -> Option<()> {
-        self.body_a = body_a;
-        self.body_b = body_b;
-        world.try_body_mut(body_a)?;
-        world.try_body_mut(body_b)?;
-        Some(())
-    }
 }
 
 impl JointDef for RopeJointDef {
@@ -59,6 +41,16 @@ impl JointDef for RopeJointDef {
                                      self.local_anchor_a,
                                      self.local_anchor_b,
                                      self.max_length)
+    }
+
+    unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {
+        Some(ffi::World_create_rope_joint(world.mut_ptr(),
+                                          world.try_body_mut(self.body_a)?.mut_ptr(),
+                                          world.try_body_mut(self.body_b)?.mut_ptr(),
+                                          self.collide_connected,
+                                          self.local_anchor_a,
+                                          self.local_anchor_b,
+                                          self.max_length))
     }
 }
 

--- a/src/dynamics/joints/rope.rs
+++ b/src/dynamics/joints/rope.rs
@@ -34,13 +34,7 @@ impl JointDef for RopeJointDef {
     }
 
     unsafe fn create<U: UserDataTypes>(&self, world: &mut World<U>) -> *mut ffi::Joint {
-        ffi::World_create_rope_joint(world.mut_ptr(),
-                                     world.body_mut(self.body_a).mut_ptr(),
-                                     world.body_mut(self.body_b).mut_ptr(),
-                                     self.collide_connected,
-                                     self.local_anchor_a,
-                                     self.local_anchor_b,
-                                     self.max_length)
+        self.try_create(world).expect("joint create failed: invalid body handle")
     }
 
     unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {

--- a/src/dynamics/joints/weld.rs
+++ b/src/dynamics/joints/weld.rs
@@ -50,8 +50,8 @@ impl WeldJointDef {
                                       anchor: &Vec2) -> Option<()> {
         self.body_a = body_a;
         self.body_b = body_b;
-        let a = world.try_body_mut(body_a)?;
-        let b = world.try_body_mut(body_b)?;
+        let a = world.try_body(body_a)?;
+        let b = world.try_body(body_b)?;
         self.local_anchor_a = a.local_point(anchor);
         self.local_anchor_b = b.local_point(anchor);
         self.reference_angle = b.angle() - a.angle();
@@ -76,6 +76,18 @@ impl JointDef for WeldJointDef {
                                      self.reference_angle,
                                      self.frequency,
                                      self.damping_ratio)
+    }
+
+    unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {
+        Some(ffi::World_create_weld_joint(world.mut_ptr(),
+                                          world.try_body_mut(self.body_a)?.mut_ptr(),
+                                          world.try_body_mut(self.body_b)?.mut_ptr(),
+                                          self.collide_connected,
+                                          self.local_anchor_a,
+                                          self.local_anchor_b,
+                                          self.reference_angle,
+                                          self.frequency,
+                                          self.damping_ratio))
     }
 }
 

--- a/src/dynamics/joints/weld.rs
+++ b/src/dynamics/joints/weld.rs
@@ -42,6 +42,21 @@ impl WeldJointDef {
         self.local_anchor_b = b.local_point(anchor);
         self.reference_angle = b.angle() - a.angle();
     }
+
+    pub fn try_init<U: UserDataTypes>(&mut self,
+                                      world: &World<U>,
+                                      body_a: BodyHandle,
+                                      body_b: BodyHandle,
+                                      anchor: &Vec2) -> Option<()> {
+        self.body_a = body_a;
+        self.body_b = body_b;
+        let a = world.try_body_mut(body_a)?;
+        let b = world.try_body_mut(body_b)?;
+        self.local_anchor_a = a.local_point(anchor);
+        self.local_anchor_b = b.local_point(anchor);
+        self.reference_angle = b.angle() - a.angle();
+        Some(())
+    }
 }
 
 impl JointDef for WeldJointDef {

--- a/src/dynamics/joints/weld.rs
+++ b/src/dynamics/joints/weld.rs
@@ -34,13 +34,7 @@ impl WeldJointDef {
                                   body_a: BodyHandle,
                                   body_b: BodyHandle,
                                   anchor: &Vec2) {
-        self.body_a = body_a;
-        self.body_b = body_b;
-        let a = world.body(body_a);
-        let b = world.body(body_b);
-        self.local_anchor_a = a.local_point(anchor);
-        self.local_anchor_b = b.local_point(anchor);
-        self.reference_angle = b.angle() - a.angle();
+        self.try_init(world, body_a, body_b, anchor).expect("joint init filed: invalid body handle");
     }
 
     pub fn try_init<U: UserDataTypes>(&mut self,
@@ -67,15 +61,7 @@ impl JointDef for WeldJointDef {
     }
 
     unsafe fn create<U: UserDataTypes>(&self, world: &mut World<U>) -> *mut ffi::Joint {
-        ffi::World_create_weld_joint(world.mut_ptr(),
-                                     world.body_mut(self.body_a).mut_ptr(),
-                                     world.body_mut(self.body_b).mut_ptr(),
-                                     self.collide_connected,
-                                     self.local_anchor_a,
-                                     self.local_anchor_b,
-                                     self.reference_angle,
-                                     self.frequency,
-                                     self.damping_ratio)
+        self.try_create(world).expect("joint create failed: invalid body handle")
     }
 
     unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {

--- a/src/dynamics/joints/wheel.rs
+++ b/src/dynamics/joints/wheel.rs
@@ -41,13 +41,7 @@ impl WheelJointDef {
                                   body_b: BodyHandle,
                                   anchor: &Vec2,
                                   axis: &Vec2) {
-        self.body_a = body_a;
-        self.body_b = body_b;
-        let a = world.body(body_a);
-        let b = world.body(body_b);
-        self.local_anchor_a = a.local_point(anchor);
-        self.local_anchor_b = b.local_point(anchor);
-        self.local_axis_a = a.local_vector(axis);
+        self.try_init(world, body_a, body_b, anchor, axis).expect("joint init filed: invalid body handle");
     }
 
     pub fn try_init<U: UserDataTypes>(&mut self,
@@ -75,18 +69,7 @@ impl JointDef for WheelJointDef {
     }
 
     unsafe fn create<U: UserDataTypes>(&self, world: &mut World<U>) -> *mut ffi::Joint {
-        ffi::World_create_wheel_joint(world.mut_ptr(),
-                                      world.body_mut(self.body_a).mut_ptr(),
-                                      world.body_mut(self.body_b).mut_ptr(),
-                                      self.collide_connected,
-                                      self.local_anchor_a,
-                                      self.local_anchor_b,
-                                      self.local_axis_a,
-                                      self.enable_motor,
-                                      self.max_motor_torque,
-                                      self.motor_speed,
-                                      self.frequency,
-                                      self.damping_ratio)
+        self.try_create(world).expect("joint create failed: invalid body handle")
     }
 
     unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {

--- a/src/dynamics/joints/wheel.rs
+++ b/src/dynamics/joints/wheel.rs
@@ -58,8 +58,8 @@ impl WheelJointDef {
                                       axis: &Vec2) -> Option<()> {
         self.body_a = body_a;
         self.body_b = body_b;
-        let a = world.try_body_mut(body_a)?;
-        let b = world.try_body_mut(body_b)?;
+        let a = world.try_body(body_a)?;
+        let b = world.try_body(body_b)?;
         self.local_anchor_a = a.local_point(anchor);
         self.local_anchor_b = b.local_point(anchor);
         self.local_axis_a = a.local_vector(axis);
@@ -87,6 +87,21 @@ impl JointDef for WheelJointDef {
                                       self.motor_speed,
                                       self.frequency,
                                       self.damping_ratio)
+    }
+
+    unsafe fn try_create<U: UserDataTypes>(&self, world: &mut World<U>) -> Option<*mut ffi::Joint> {
+        Some(ffi::World_create_wheel_joint(world.mut_ptr(),
+                                           world.try_body_mut(self.body_a)?.mut_ptr(),
+                                           world.try_body_mut(self.body_b)?.mut_ptr(),
+                                           self.collide_connected,
+                                           self.local_anchor_a,
+                                           self.local_anchor_b,
+                                           self.local_axis_a,
+                                           self.enable_motor,
+                                           self.max_motor_torque,
+                                           self.motor_speed,
+                                           self.frequency,
+                                           self.damping_ratio))
     }
 }
 

--- a/src/dynamics/joints/wheel.rs
+++ b/src/dynamics/joints/wheel.rs
@@ -49,6 +49,22 @@ impl WheelJointDef {
         self.local_anchor_b = b.local_point(anchor);
         self.local_axis_a = a.local_vector(axis);
     }
+
+    pub fn try_init<U: UserDataTypes>(&mut self,
+                                      world: &World<U>,
+                                      body_a: BodyHandle,
+                                      body_b: BodyHandle,
+                                      anchor: &Vec2,
+                                      axis: &Vec2) -> Option<()> {
+        self.body_a = body_a;
+        self.body_b = body_b;
+        let a = world.try_body_mut(body_a)?;
+        let b = world.try_body_mut(body_b)?;
+        self.local_anchor_a = a.local_point(anchor);
+        self.local_anchor_b = b.local_point(anchor);
+        self.local_axis_a = a.local_vector(axis);
+        Some(())
+    }
 }
 
 impl JointDef for WheelJointDef {

--- a/src/dynamics/world.rs
+++ b/src/dynamics/world.rs
@@ -132,6 +132,19 @@ impl<U: UserDataTypes> World<U> {
         }
     }
 
+    pub fn try_create_joint<JD: JointDef>(&mut self, def: &JD) -> Option<JointHandle>
+        where U::JointData: Default
+    {
+        self.try_create_joint_with(def, U::JointData::default())
+    }
+
+    pub fn try_create_joint_with<JD: JointDef>(&mut self, def: &JD, data: U::JointData) -> Option<JointHandle> {
+        unsafe {
+            let joint = def.try_create(self)?;
+            Some(self.joints.insert_with(|h| MetaJoint::new(joint, h, data)))
+        }
+    }
+
     pub fn joint(&self, handle: JointHandle) -> Ref<MetaJoint<U>> {
         self.joints.get(handle).expect("invalid joint handle")
     }

--- a/src/dynamics/world.rs
+++ b/src/dynamics/world.rs
@@ -92,6 +92,14 @@ impl<U: UserDataTypes> World<U> {
         self.bodies.get_mut(handle).expect("invalid body handle")
     }
 
+    pub fn try_body(&self, handle: BodyHandle) -> Option<Ref<MetaBody<U>>> {
+        self.bodies.get(handle)
+    }
+
+    pub fn try_body_mut(&self, handle: BodyHandle) -> Option<RefMut<MetaBody<U>>> {
+        self.bodies.get_mut(handle)
+    }
+
     pub fn destroy_body(&mut self, handle: BodyHandle) {
         let mut body = self.bodies.remove(handle);
 
@@ -130,6 +138,14 @@ impl<U: UserDataTypes> World<U> {
 
     pub fn joint_mut(&self, handle: JointHandle) -> RefMut<MetaJoint<U>> {
         self.joints.get_mut(handle).expect("invalid joint handle")
+    }
+
+    pub fn try_joint(&self, handle: JointHandle) -> Option<Ref<MetaJoint<U>>> {
+        self.joints.get(handle)
+    }
+
+    pub fn try_joint_mut(&self, handle: JointHandle) -> Option<RefMut<MetaJoint<U>>> {
+        self.joints.get_mut(handle)
     }
 
     pub fn destroy_joint(&mut self, handle: JointHandle) {


### PR DESCRIPTION
The current library didn't seem to have a way to access bodies/fixtures/joints without potentially panicking, so I added new try_ variants of the getter functions. This makes it so user programs can more easily handle the error in the case of an expired or invalid handle.